### PR TITLE
MERC-5890 Change naming WIDGET_BUILDER_STORE_HASH

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The widget builder reads the credentials from environment variables. You will ne
 - `WIDGET_BUILDER_AUTH_ID` - The primary identifier of this set of credentials (Client ID).
 - `WIDGET_BUILDER_AUTH_TOKEN` - The private authorization token (Auth token).
 
-- `WIDGET_BUILDER_STORE_ID` - The primary hash identifier of the store the credentials belong to.
+- `WIDGET_BUILDER_STORE_HASH` - The primary hash identifier of the store the credentials belong to.
 
 You can also run using a format like the following:
 
 ```
-WIDGET_BUILDER_AUTH_ID=REDACTED WIDGET_BUILDER_AUTH_TOKEN=REDACTED WIDGET_BUILDER_STORE_ID=REDACTED widget-builder
+WIDGET_BUILDER_AUTH_ID=REDACTED WIDGET_BUILDER_AUTH_TOKEN=REDACTED WIDGET_BUILDER_STORE_HASH=REDACTED widget-builder
 ```
 
 ### Running the builder

--- a/src/services/api/widget.ts
+++ b/src/services/api/widget.ts
@@ -34,7 +34,7 @@ export function getWidget(data: WidgetPreviewRenderRequest): Promise<string> {
                 'X-Auth-Token': AUTH_CONFIG.authToken,
             },
             data,
-            url: widgetApi.widgetPreviewRender(AUTH_CONFIG.storeId as string),
+            url: widgetApi.widgetPreviewRender(AUTH_CONFIG.storeHash as string),
         }).then((response: AxiosResponse<WidgetPreviewRenderResponse>) => {
             resolve(response.data.data.html);
         }).catch((err: Error) => reject(err));

--- a/src/services/auth/auth.test.ts
+++ b/src/services/auth/auth.test.ts
@@ -3,7 +3,7 @@ import checkCredentials from './checkAuth';
 describe('Auth credential status check', () => {
     it('succeeds if credentials are present', () => {
         const checkStatus = checkCredentials({
-            storeId: '123456',
+            storeHash: '123456',
             authId: 'abc123',
             authToken: 'xyz456',
         });
@@ -13,7 +13,7 @@ describe('Auth credential status check', () => {
 
     it('fails if any of the credentials are missing', () => {
         const checkStatus = checkCredentials({
-            storeId: '123456',
+            storeHash: '123456',
             authId: 'abc123',
             authToken: '',
         });

--- a/src/services/auth/authConfig.ts
+++ b/src/services/auth/authConfig.ts
@@ -1,11 +1,11 @@
 export interface AuthConfig {
-    storeId?: string;
+    storeHash?: string;
     authId?: string;
     authToken?: string;
 }
 
 const AUTH_CONFIG: AuthConfig = {
-    storeId: process.env.WIDGET_BUILDER_STORE_ID,
+    storeHash: process.env.WIDGET_BUILDER_STORE_HASH,
     authId: process.env.WIDGET_BUILDER_AUTH_ID,
     authToken: process.env.WIDGET_BUILDER_AUTH_TOKEN,
 };


### PR DESCRIPTION
We should refer to store id in the README as WIDGET_BUILDER_STORE_HASH instead of WIDGET_BUILDER_STORE_ID. We use store hash externally, and we refer to it that way in our developer docs: https://developer.bigcommerce.com/api-docs/getting-started/making-requests