### PR TITLE
feat(merc): MERC-7912 Ensure schema.json is the source of truth.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-server": "cd src/server && tsc -p tsconfig.server.json",
     "build-cli": "cd src/cli && tsc -p tsconfig.cli.json",
     "build": "npm run build-cli && npm run build-server && npm run build-client",
-    "install-cli": "npm run build && npm install -g",
+    "install-cli": "npm install; npm run build && npm install -g",
     "server": "nodemon dist/server/index.js",
     "start": "npm run build && npm run server",
     "dev-client": "webpack-dev-server --mode development --devtool inline-source-map --hot",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,13 +34,7 @@ function setupFileWatcher({ directory, sockets, options }: Watcher) {
         log.info(messages.fileChangeDetected(fileName));
 
         switch (fileName) {
-            // When the widget template or configuration changes, we should live reload
             case WidgetFileType.TEMPLATE:
-                liveReload({
-                    directory, sockets, fileEvent, filePath,
-                });
-                break;
-
             case WidgetFileType.CONFIGURATION:
             case WidgetFileType.QUERY:
                 liveReload({
@@ -60,20 +54,19 @@ function setupFileWatcher({ directory, sockets, options }: Watcher) {
             case WidgetFileType.SCHEMA:
                 // Validate the schema against json schema
                 validateSchema(directory);
+                generateConfig(directory);
 
-                // Check whether we need to regenerate a config file
-                if (options.generateConfig) {
-                    generateConfig(directory);
-                }
+                liveReload({
+                    directory, sockets, fileEvent, filePath, options,
+                });
+
                 break;
 
             case WidgetFileType.META:
                 // We are not currently handling this file type
                 break;
 
-            default:
-                // Do nothing
-                break;
+            default: break;
         }
     });
 }


### PR DESCRIPTION
## What? Why?
Currently changes to schema.json doesn't reflect locally nor is the configurations updated.

We need to treat schema.json as the source of truth 

## Testing / Proof
Tested locally

- start a widget builder locally
- make a change to schema.json
- observe livereload with changes in effect

