### PR TITLE
Add delete command

### DIFF
--- a/src/cli/delete/widgetTemplateDelete.ts
+++ b/src/cli/delete/widgetTemplateDelete.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'fs';
+import path from 'path';
+
+import { Command } from 'commander';
+
+import deleteWidgetTemplate from '../../services/widgetTemplate/delete';
+import { log, messages } from '../../messages';
+import checkCredentials from '../../services/auth/checkAuth';
+import AUTH_CONFIG from '../../services/auth/authConfig';
+
+const widgetTemplateDelete = () => {
+    const program = new Command('delete');
+
+    return program
+        .arguments('<widget-template>')
+        .description('Delete the widget template on the store belonging to the env config')
+        .usage('<widget-template>')
+        .action((widgetTemplate) => {
+            const widgetTemplateDir = path.resolve(`./${widgetTemplate}`);
+            if (!checkCredentials(AUTH_CONFIG)) {
+                process.exit(1);
+            }
+
+            if (!widgetTemplate) {
+                log.error(messages.widgetRelease.invalidName);
+                return;
+            }
+
+            if (!existsSync(widgetTemplateDir)) {
+                log.error('Widget Template doesn\'t exist');
+                return;
+            }
+
+            deleteWidgetTemplate(widgetTemplate, widgetTemplateDir);
+        });
+};
+
+export default widgetTemplateDelete;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import createStarterTemplate from './create/starterTemplate';
 import start from './run/start';
 import widgetTemplatePublish from './deployment/widgetTemplatePublish';
+import widgetTemplateDelete from './delete/widgetTemplateDelete';
 import validateCommands from './run/validate';
 import init from './run/init';
 
@@ -18,6 +19,7 @@ cli
     .addCommand(start())
     .addCommand(validateCommands())
     .addCommand(createStarterTemplate())
-    .addCommand(widgetTemplatePublish());
+    .addCommand(widgetTemplatePublish())
+    .addCommand(widgetTemplateDelete());
 
 cli.parse(process.argv);

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -52,5 +52,10 @@ export const messages = {
         failure: 'Unable to generate data to release, please check the widget template config or template data',
         invalidName: 'Please provide a valid widget-template',
     },
+    widgetDelete: {
+        success: (widgetName: string) => `${widgetName} successfully deleted!`,
+        failure: 'Unable to delete the widget, please check template yml',
+        invalidUuid: 'Please provide a valid widget-template UUID',
+    },
 };
 /* eslint-enable max-len */

--- a/src/services/api/widget.ts
+++ b/src/services/api/widget.ts
@@ -14,6 +14,10 @@ interface WidgetPreviewRenderResponse {
     };
 }
 
+interface widgetBuilderDeleteResponse {
+    data: {};
+}
+
 export interface WidgetPreviewRenderRequest {
     widget_configuration: object;
     widget_template: string;
@@ -60,6 +64,22 @@ export const publishWidget = (
         },
         data: widgetData,
         url: `${widgetApi.widgetTemplatePublish}${uuid ? `/${uuid}` : ''}`,
+    })
+        .then(({ data: { data } }) => resolve(data))
+        .catch(error => reject(error));
+});
+
+export const deleteWidget = (
+    uuid: string | null,
+): Promise<widgetBuilderDeleteResponse> => new Promise((resolve, reject) => {
+    Axios({
+        method: 'delete',
+        headers: {
+            Accept: 'application/json',
+            'X-Auth-Client': AUTH_CONFIG.authId,
+            'X-Auth-Token': AUTH_CONFIG.authToken,
+        },
+        url: `${widgetApi.widgetTemplatePublish}${`/${uuid}`}`,
     })
         .then(({ data: { data } }) => resolve(data))
         .catch(error => reject(error));

--- a/src/services/widgetTemplate/delete.ts
+++ b/src/services/widgetTemplate/delete.ts
@@ -1,0 +1,17 @@
+import { log, messages } from '../../messages';
+import { deleteWidget } from '../api/widget';
+import track from './track';
+
+const deleteWidgetTemplate = async (widgetName: string, widgetTemplateDir: string) => {
+    const widgetTemplateUuid = track.isTracked(widgetTemplateDir);
+
+    try {
+        await deleteWidget(widgetTemplateUuid);
+        log.success(messages.widgetDelete.success(widgetName));
+
+    } catch {
+        log.error(messages.widgetDelete.failure);
+    }
+};
+
+export default deleteWidgetTemplate;


### PR DESCRIPTION
## What? Why?
Currently, the only way to delete a widget template that’s been published via widget-builder is to make a DELETE request via API. This PR adds a delete command that will delete widgets published by widget-builder  (using the UUID from widget.yml).

## Testing / Proof
...

