### PR TITLE
Correct validate command options

### DIFF
--- a/src/cli/run/validate.ts
+++ b/src/cli/run/validate.ts
@@ -10,8 +10,9 @@ import validateTranslation from '../../services/translation/validate';
 
 const helperText = `
 Usage:
-    --validate-schema sample-widget/schema.json
-    --validate-query-params sample-widget/queryParamsBuilder.json
+    widget-builder validate --schema sample-widget
+    widget-builder validate --query-params sample-widget
+    widget-builder validate --translation sample-widget
 `;
 
 const validateCommands = () => {
@@ -24,12 +25,13 @@ const validateCommands = () => {
         .option('--translation', 'validates schema_translation.json file')
         .addHelpText('afterAll', helperText)
         .action((name, options) => {
-            const directory = path.resolve('.');
-            if (options.validateSchema) {
+            const directory = path.resolve('.', name);
+            
+            if (options.schema) {
                 validateSchema(directory);
             }
 
-            if (options.validateQueryParamsBuilder) {
+            if (options.queryParams) {
                 validateQueryParamsBuilder(directory);
             }
 


### PR DESCRIPTION
What? Why?
The current usage and options for the validate command do not run. This PR corrects these and allows for the command to be run from parent directories. Issue reported as a comment here: #90 

Testing / Proof
A test environment is available on the [test-fix-validate-command-options](https://github.com/Space48/widget-builder/tree/test-fix-validate-command-options) branch of the Space48 fork. The following commands have been tested with valid and invalid schemas:

`widget-builder validate --schema test-widget`
`widget-builder validate --query-params test-widget`
`widget-builder validate --translation test-widget`