### PR TITLE
Update circleCI to build with node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,10 @@ orbs:
 #####################################################
 # Aliases
 #####################################################
-workspace_root: &workspace_root
-  ~/repo
-
-executor_defaults: &executor_defaults
-  executor:
-    name: node/node
-    node-version: "14"
+executors:
+  node:
+    docker:
+      - image: cimg/node:14.18
 
 #####################################################
 # Commands
@@ -32,23 +29,23 @@ commands:
 #####################################################
 jobs:
   install-dependencies:
-    <<: *executor_defaults
+    executor: node
     steps:
       - install-dependencies
   unit-tests:
-    <<: *executor_defaults
+    executor: node
     resource_class: large
     steps:
       - install-dependencies
       - run: npm run test
   build-assets:
-    <<: *executor_defaults
+    executor: node
     steps:
       - install-dependencies
       - run: npm run lint
       - run: npm run build
       - persist_to_workspace:
-          root: *workspace_root
+          root: .
           paths:
             - dist
 


### PR DESCRIPTION
## What? Why?
Update circleCI to build with node14 image. Node 10 image is not supported anymore
