### PR TITLE
Update publish widget template -> push widget template

### DIFF
--- a/src/cli/deployment/widgetTemplatePublish.ts
+++ b/src/cli/deployment/widgetTemplatePublish.ts
@@ -11,12 +11,13 @@ import checkCredentials from '../../services/auth/checkAuth';
 import AUTH_CONFIG from '../../services/auth/authConfig';
 
 const widgetTemplatePublish = () => {
-    const program = new Command('publish');
+    const program = new Command('push');
 
     return program
         .arguments('<widget-template>')
         .description('Releases the widget template to the store belonging to the env config')
         .usage('<widget-template>')
+        .alias('publish')
         .action((widgetTemplate) => {
             const widgetTemplateDir = path.resolve(`./${widgetTemplate}`);
             if (!checkCredentials(AUTH_CONFIG)) {
@@ -24,7 +25,7 @@ const widgetTemplatePublish = () => {
             }
 
             if (!widgetTemplate) {
-                log.error(messages.widgetRelease.invalidName);
+                log.error(messages.pushWidgetTemplate.invalidName);
                 return;
             }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -47,7 +47,7 @@ export const messages = {
         removeError: (path: string) => `There was a problem removing ${path}, you may have to delete this manually`,
         removeSuccess: (path: string) => `Successfully removed ${path}`,
     },
-    widgetRelease: {
+    pushWidgetTemplate: {
         success: (widgetName: string) => `${widgetName} successfully published!`,
         failure: 'Unable to generate data to release, please check the widget template config or template data',
         invalidName: 'Please provide a valid widget-template',

--- a/src/services/widgetTemplate/publish.ts
+++ b/src/services/widgetTemplate/publish.ts
@@ -57,12 +57,12 @@ const publishWidgetTemplate = async (widgetName: string, widgetTemplateDir: stri
 
         if (!widgetTemplateUuid) {
             track.startTracking(widgetTemplateDir, uuid);
-            log.success(messages.widgetRelease.success(widgetName));
+            log.success(messages.pushWidgetTemplate.success(widgetName));
         } else {
             log.success(`Successfully updated ${widgetName}`);
         }
     } catch {
-        log.error(messages.widgetRelease.failure);
+        log.error(messages.pushWidgetTemplate.failure);
     }
 };
 


### PR DESCRIPTION
## What? Why?
Update publish widget template -> push widget template. This is backwards compatible, meaning `widget-builder publish <widget-template>` will still be supported.

<img width="895" alt="Screen Shot 2022-04-28 at 4 07 05 PM" src="https://user-images.githubusercontent.com/33278039/165861888-b60782a4-7744-45b7-8d95-7d2b8c41d17b.png">


## Testing / Proof
Tested locally, steps to test
(1) Pull this PR
(2) Run `npm run build` to update local build with this branch
(3) Run `widget-builder -h` to make sure `push` is added in list of commands 
(4) Run `widget-builder push <widget-template>` to make sure command works properly

