### PR TITLE
[Eurostep] Adapt widget-builder to multi channel (MSF)

### DIFF
--- a/src/cli/deployment/widgetTemplatePublish.ts
+++ b/src/cli/deployment/widgetTemplatePublish.ts
@@ -12,6 +12,7 @@ import AUTH_CONFIG from '../../services/auth/authConfig';
 
 const widgetTemplatePublish = () => {
     const program = new Command('publish');
+    const channelIdsToPublish = process.env.WIDGET_BUILDER_CHANNEL_ID ? process.env.WIDGET_BUILDER_CHANNEL_ID.split(',') : ['1'];
 
     return program
         .arguments('<widget-template>')
@@ -33,7 +34,9 @@ const widgetTemplatePublish = () => {
                 return;
             }
 
-            publishWidgetTemplate(widgetTemplate, widgetTemplateDir);
+            channelIdsToPublish.forEach((channelId) => {
+                publishWidgetTemplate(widgetTemplate, widgetTemplateDir, channelId);
+            });
         });
 };
 


### PR DESCRIPTION
## What? Why?
The PR wants to allow the developer to publish the widget-template to a channel different from the default channel.
Starting from the automatically created environment variable in the widget folder WIDGET_BUILDER_CHANNEL_ID, the developer can add in his local a list of channels (comma separated) where he wants to publish the template, ex:
WIDGET_BUILDER_CHANNEL_ID=1,2

The change in the library removes the hardcoding to the default channel, and **runs the publish for each channel inserted in the .env variable**.
We preferred to manage it from the .env variable instead of using options since it's common to publish and update the widgets to every available channels during the project (so the dev shouldn't have to add options like --c=1,2 for every push, but instead change the the .env when he needs to do something different from the daily routine). 

For any doubts about the implementation please send an email to:
- francesco.pozzobon@eurostep.it
- bigcommerce@eurostep.it

## Testing / Proof
The PR doesn't include implementations in the test files, ofc it is tested and working on Eurostep Commerce stores.
TBAdded: there is no check if the channel exists on the publish, if a channel doesn't exist the dev will receive a successful message even if nothing was published (since the channel id is not existent)

