### PR TITLE
Update init script to reflect MSF changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can find more information here. https://support.bigcommerce.com/s/article/St
 ? What is the Client ID? xxxxxxxxxxxxx
 ? What is the Access Token? xxxxxxxxxxxxx
 ? What is the API Path? https://api.bigcommerce.com/stores/xxxxx/v3/
+? What is the Channel ID or ID\'s you would like to publish your widgets to? Seperate channel ID\'s with comma.? (1,2,3,4)
 [2021-09-08T15:12:40.271Z] Successfully created your configuration, you're all set!
 ```
 ### Resetting configurations

--- a/src/cli/run/init.ts
+++ b/src/cli/run/init.ts
@@ -34,6 +34,11 @@ const configQuestionnaire = [
             });
         },
     },
+    {
+        type: 'input',
+        name: 'channelId',
+        message: 'What is the Channel ID or ID\'s you would like to publish your widgets to? Seperate channel ID\'s with comma.',        
+    }    
 ];
 
 const init = () => {

--- a/src/cli/run/init.ts
+++ b/src/cli/run/init.ts
@@ -37,9 +37,9 @@ const configQuestionnaire = [
     {
         type: 'input',
         name: 'channelId',
-        message: `What is the Channel ID or ID\'s you would like to publish your widgets to? 
-        Seperate channel ID\'s with comma.`,
-    }    
+        message: `What is the Channel ID or ID's you would like to publish your widgets to?
+        Seperate channel ID's with comma.`,
+    },
 ];
 
 const init = () => {

--- a/src/cli/run/init.ts
+++ b/src/cli/run/init.ts
@@ -37,7 +37,8 @@ const configQuestionnaire = [
     {
         type: 'input',
         name: 'channelId',
-        message: 'What is the Channel ID or ID\'s you would like to publish your widgets to? Seperate channel ID\'s with comma.',        
+        message: `What is the Channel ID or ID\'s you would like to publish your widgets to? 
+        Seperate channel ID\'s with comma.`,
     }    
 ];
 

--- a/src/services/auth/generate.test.ts
+++ b/src/services/auth/generate.test.ts
@@ -11,12 +11,13 @@ const config = {
     clientId: 'someClientId',
     accessToken: 'sometokenvalue',
     apiPath: 'https://api.bigcommerce.com/stores/storeHash/v3/',
+    channelId: 'someString',
 };
 
 const configuration = `
 WIDGET_BUILDER_AUTH_ID=${config.clientId}
 WIDGET_BUILDER_AUTH_TOKEN=${config.accessToken}
-WIDGET_BUILDER_CHANNEL_ID=1
+WIDGET_BUILDER_CHANNEL_ID=${config.channelId}
 WIDGET_BUILDER_API_GATEWAY_BASE=${config.apiPath.replace(/\/$/, '')}
 `;
 

--- a/src/services/auth/generate.ts
+++ b/src/services/auth/generate.ts
@@ -9,16 +9,17 @@ interface EnvironmentInterface {
     clientId: string;
     accessToken: string;
     apiPath: string;
+    channelId: string;
 }
 
 const generateConfig = ({
-    clientId, accessToken, apiPath,
+    clientId, accessToken, channelId, apiPath,
 }: EnvironmentInterface) => {
     const dir = resolve('.');
     const configuration = `
 WIDGET_BUILDER_AUTH_ID=${clientId}
 WIDGET_BUILDER_AUTH_TOKEN=${accessToken}
-WIDGET_BUILDER_CHANNEL_ID=1
+WIDGET_BUILDER_CHANNEL_ID=${channelId}
 WIDGET_BUILDER_API_GATEWAY_BASE=${apiPath.replace(/\/$/, '')}
 `;
 


### PR DESCRIPTION
## What? Why?
**This should not be merged before #110 !**

This PR updates the `widget-builder init` script to support #110 
So that we can add channel id's as a comma separated list on `.env` generation.

README file has been updated to reflect the changes to `widget-builder init`

## Testing / Proof
Test has been updated to support this new feature
