### PR TITLE
Extended cli tool to publish widgets across multiple channels

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,2 +1,3 @@
 export const port: string = process.env.WIDGET_BUILDER_PORT || '8080';
 export const host: string = process.env.WIDGET_BUILDER_HOST || 'http://localhost';
+export const channelId = process.env.WIDGET_BUILDER_CHANNEL_ID ? parseInt(process.env.WIDGET_BUILDER_CHANNEL_ID, 10) : 1;

--- a/src/services/widgetRenderer/widgetRenderer.ts
+++ b/src/services/widgetRenderer/widgetRenderer.ts
@@ -6,8 +6,7 @@ import widgetTemplateLoader from '../widgetTemplate/widgetTemplateLoader/widgetT
 import widgetConfigLoader from '../widgetConfig/widgetConfigLoader/widgetConfigLoader';
 import queryLoader from '../query/queryLoader/queryLoader';
 import queryParamsLoader from '../query/queryParamsLoader/queryParamsLoader';
-
-const channelId = process.env.WIDGET_BUILDER_CHANNEL_ID ? parseInt(process.env.WIDGET_BUILDER_CHANNEL_ID, 10) : 1;
+import { channelId } from '../../config';
 
 const getInitialRenderingPayload = (): WidgetPreviewRenderRequest => ({
     widget_configuration: {},

--- a/src/services/widgetTemplate/publish.ts
+++ b/src/services/widgetTemplate/publish.ts
@@ -4,6 +4,7 @@ import queryParamsLoader from '../query/queryParamsLoader/queryParamsLoader';
 import { publishWidget } from '../api/widget';
 import WidgetFileType, { FileLoaderResponse } from '../../types';
 import schemaLoader from '../schema/schemaLoader/schemaLoader';
+import { channelId } from '../../config';
 
 import widgetTemplateLoader from './widgetTemplateLoader/widgetTemplateLoader';
 import track from './track';
@@ -21,7 +22,7 @@ const widgetTemplatePayload = (widgetName: string): CreateWidgetTemplateReq => (
     schema: [],
     template: '',
     storefront_api_query: '',
-    channel_id: 1,
+    channel_id: channelId,
 });
 
 const publishWidgetTemplate = async (widgetName: string, widgetTemplateDir: string) => {


### PR DESCRIPTION
## What? Why?
For Focusrite, we need multiple BC instances each with multiple storefronts. This means we need to be able to deploy widgets to channels other than the default (channel_id=1)

## Testing / Proof
...

