### PR TITLE
Update publish default channel id

### DIFF
--- a/src/services/widgetTemplate/publish.ts
+++ b/src/services/widgetTemplate/publish.ts
@@ -16,12 +16,14 @@ interface CreateWidgetTemplateReq {
     channel_id: number;
 }
 
+const channelId = process.env.WIDGET_BUILDER_CHANNEL_ID ? parseInt(process.env.WIDGET_BUILDER_CHANNEL_ID, 10) : 1;
+
 const widgetTemplatePayload = (widgetName: string): CreateWidgetTemplateReq => ({
     name: widgetName,
     schema: [],
     template: '',
     storefront_api_query: '',
-    channel_id: 1,
+    channel_id: channelId,
 });
 
 const publishWidgetTemplate = async (widgetName: string, widgetTemplateDir: string) => {


### PR DESCRIPTION
## What? Why?
Update Publish to use  `process.env.WIDGET_BUILDER_CHANNEL_ID` and not default to channel 1. This will support publish for multi storefronts.

<img width="1512" alt="Screenshot 2023-05-24 at 8 34 07 PM" src="https://github.com/bigcommerce/widget-builder/assets/33278039/f715d438-95e3-4534-8315-9aadf7e8d6e4">

## Testing / Proof
Tested locally, updated screenshots

