### PR TITLE
fix: add text setting to allowed list of settings

### DIFF
--- a/src/services/schema/schemaValidator/jsonSchema.ts
+++ b/src/services/schema/schemaValidator/jsonSchema.ts
@@ -113,6 +113,7 @@ const jsonSchema = {
                 { $ref: '#/definitions/rangeSetting' },
                 { $ref: '#/definitions/regexInputSetting' },
                 { $ref: '#/definitions/selectSetting' },
+                { $ref: '#/definitions/textSetting' },
                 { $ref: '#/definitions/toggleSetting' },
                 { $ref: '#/definitions/typographySetting' },
                 { $ref: '#/definitions/visibilitySetting' },


### PR DESCRIPTION
# Issue

When using the UI type of `text`, an error is thrown stating that the it is not in the list of allowed values. The UI type is valid.

```json
{
  "type": "text",
  "id": "text",
  "label": "Text",
  "default": "Lorem ipsum dolor sit amit"
},
```

## Error

```json
[
  {
    "start": {
      "line": 1,
      "column": 1013,
      "offset": 1012
    },
    "end": {
      "line": 1,
      "column": 1266,
      "offset": 1265
    },
    "error": "/0/sections/0/settings/2: oneOf should match exactly one schema in oneOf",
    "path": "/0/sections/0/settings/2"
  },
  {
    "start": {
      "line": 1,
      "column": 1021,
      "offset": 1020
    },
    "end": {
      "line": 1,
      "column": 1027,
      "offset": 1026
    },
    "error": "/0/sections/0/settings/2/type should be equal to one of the allowed values: alignment, boolean, boxModel, code, color, element, imageManager, input, number, productId, productImage, range, regexInput, select, toggle, typography, visibility",
    "path": "/0/sections/0/settings/2/type"
  }
]
```

## Solution

In file `src/services/schema/schemaValidator/jsonSchema.ts`, the `definitions.labeledSchemaSetting.oneOf` array is missing the value for `definitions.textSetting`. Reinstalling after making this change fixes the error.