### PR TITLE
Fix install-cli command on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-server": "cd src/server && tsc -p tsconfig.server.json",
     "build-cli": "cd src/cli && tsc -p tsconfig.cli.json",
     "build": "npm run build-cli && npm run build-server && npm run build-client",
-    "install-cli": "npm install; npm run build && npm install -g",
+    "install-cli": "npm install && npm run build && npm install -g",
     "server": "nodemon dist/server/index.js",
     "start": "npm run build && npm run server",
     "dev-client": "webpack-dev-server --mode development --devtool inline-source-map --hot",


### PR DESCRIPTION
## What? Why?
Fix the `install-cli` command to use a `&&` instead of a `;` to support windows.


