### PR TITLE
Provide user feedback on widget preview failure

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -39,6 +39,7 @@ export const messages = {
     socketConnected: () => 'Socket connected.',
     socketDisconnected: () => 'Socket disconnected.',
     unauthorizedAccess: () => 'Unauthorized access, please check your credentials again',
+    templateError: (err: string) => `An error occurred when previewing the widget template: ${err}`,
     generalError: (err: string) => `Something went wrong: ${err}`,
     createWidgetTemplate: {
         createError: (fileName: string, directory?: string) => `There was a problem creating ${fileName} ${directory ? `in ${directory}` : ''}`,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -108,9 +108,12 @@ export default function startWidgetBuilder(directory: string, options: Options) 
             .catch((error) => {
                 try {
                     const { message } = error.toJSON();
+                    const { data: errorResponse } = error.response;
 
                     if (message.match('401')) {
                         log.error(messages.unauthorizedAccess());
+                    } else if (errorResponse.status === 422) {
+                        log.error(messages.templateError(errorResponse.errors.details));
                     } else {
                         log.error(messages.generalError(message));
                     }


### PR DESCRIPTION
## What? Why?
Ensure that when the widget preview fails, we are returning/logging the error information for a proper developer feedback cycle.

## Testing / Proof
<img width="809" alt="image" src="https://github.com/user-attachments/assets/e510238f-fb40-4c3e-b198-79427da0ab0b">

